### PR TITLE
Lower Spree dependency to ~> 3.0

### DIFF
--- a/spree_sitemap.gemspec
+++ b/spree_sitemap.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.add_runtime_dependency 'spree_core', '~> 3.2.0.alpha'
+  s.add_runtime_dependency 'spree_core', '~> 3.0'
   s.add_runtime_dependency 'sitemap_generator', '~> 5.1.0'
 
   s.add_development_dependency 'database_cleaner', '~> 1.4.0'


### PR DESCRIPTION
- as there are no incompatible differences between the set 3.2 and 3.0,
  
  while the same will allow for stores with older versions of Spree
  
  to use it.
